### PR TITLE
Conexão com banco de dados

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,8 @@ RUN apt-get update && apt-get install -y \
     libonig-dev \
     libxml2-dev \
     zip \
-    unzip
+    unzip \
+    default-mysql-client
 
 # Clear cache
 RUN apt-get clean && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
Após um teste inicial na branch main, recebi o erro em que o comando do mysql não havia sido encontrado, com isso adicionei ao Dockerfile a instalação da dependência que faltava.