### PR TITLE
Chore: Update docker-compose.yml to support Mac M2 Setup

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
         build:
             context: .
             dockerfile: Dockerfile
+        container_name: app
         restart: unless-stopped
         working_dir: /var/www/
         volumes:
@@ -18,6 +19,7 @@ services:
     # nginx
     nginx:
         image: nginx:alpine
+        container_name: nginx
         restart: unless-stopped
         ports:
             - "8989:80"
@@ -29,7 +31,8 @@ services:
 
     # db mysql
     db:
-        image: mysql:5.7.22
+        image: mysql/mysql-server:8.0
+        container_name: mysql
         restart: unless-stopped
         environment:
             MYSQL_DATABASE: ${DB_DATABASE:-laravel}
@@ -46,6 +49,7 @@ services:
     # PHPMyAdmin
     phpmyadmin:
         image: phpmyadmin/phpmyadmin
+        container_name: phpmyadmin
         restart: unless-stopped
         ports:
             - "8080:80"
@@ -58,7 +62,8 @@ services:
 
     # redis
     redis:
-        image: redis:latest
+        image: redis:alpine
+        container_name: redis
         networks:
             - laravel
 


### PR DESCRIPTION
When running `docker-compose up -d` on a MacBook Pro M2 gave an error and messages appeared as below:
```
[+] Running 0/1
 ⠧ db Pulling   
no matching manifest for linux/arm64/v8 in the manifest list entries
```

I updated the MySql and Redis versions and `docker-compose up -d` run the containers correctly.  

This pull request includes several updates to the `docker-compose.yml` file to improve container management and update service images. The most important changes include adding container names to each service and updating the MySQL and Redis images.

Container management improvements:

* Added `container_name` to the `app` service in `docker-compose.yml`.
* Added `container_name` to the `nginx` service in `docker-compose.yml`.
* Added `container_name` to the `mysql` service in `docker-compose.yml`.
* Added `container_name` to the `phpmyadmin` service in `docker-compose.yml`.
* Added `container_name` to the `redis` service in `docker-compose.yml`.

Service image updates:

* Updated the MySQL image from `mysql:5.7.22` to `mysql/mysql-server:8.0` in `docker-compose.yml`.
* Updated the Redis image from `redis:latest` to `redis:alpine` in `docker-compose.yml`.